### PR TITLE
feat - persist download cache in sqlite, skip re-download on cache hit

### DIFF
--- a/cogs/music_system/cog.py
+++ b/cogs/music_system/cog.py
@@ -73,7 +73,14 @@ class Music(commands.Cog):
 
     async def _resolve_query(self, query: str) -> list[Track]:
         is_url = query.startswith('http://') or query.startswith('https://')
-        data = await self.youtube.extract(query) if is_url else await self.youtube.search(query, limit=1)
+        if is_url:
+            cached = self.youtube.lookup_cached_url(query)
+            if cached:
+                logger.info(f"URL already downloaded, skipping extraction: {query}")
+                return [Track.from_dict(cached)]
+            data = await self.youtube.extract(query)
+        else:
+            data = await self.youtube.search(query, limit=1)
         return [Track.from_dict(d) for d in data]
 
     @staticmethod
@@ -120,9 +127,10 @@ class Music(commands.Cog):
             return
 
         player.record_played(track)
-        file_path = await self.youtube.get_audio_file(
-            {'id': track.id, 'title': track.title, 'webpage_url': track.webpage_url}
-        )
+        file_path = await self.youtube.get_audio_file({
+            'id': track.id, 'title': track.title, 'webpage_url': track.webpage_url,
+            'duration': track.duration, 'thumbnail': track.thumbnail,
+        })
         if not file_path:
             logger.error(f"Could not get audio for '{track.title}', skipping")
             await self._advance(guild)

--- a/cogs/music_system/db.py
+++ b/cogs/music_system/db.py
@@ -1,0 +1,80 @@
+"""SQLite-backed download registry: persists video_id -> mp3 path across bot restarts,
+and drives LRU eviction so the downloads dir doesn't grow forever.
+"""
+import logging
+import os
+import sqlite3
+from typing import Optional
+
+logger = logging.getLogger('discord.music')
+
+DB_PATH = os.path.join('downloads', 'tracks.db')
+
+
+class TrackDB:
+    def __init__(self, db_path: str = DB_PATH):
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self.conn.execute('''
+            CREATE TABLE IF NOT EXISTS tracks (
+                video_id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                webpage_url TEXT NOT NULL,
+                duration INTEGER NOT NULL DEFAULT 0,
+                thumbnail TEXT NOT NULL DEFAULT '',
+                file_path TEXT NOT NULL,
+                downloaded_at TEXT NOT NULL DEFAULT (datetime('now')),
+                last_played_at TEXT,
+                play_count INTEGER NOT NULL DEFAULT 0
+            )
+        ''')
+        self.conn.commit()
+
+    def get(self, video_id: str) -> Optional[dict]:
+        row = self.conn.execute(
+            'SELECT video_id, title, webpage_url, duration, thumbnail, file_path FROM tracks WHERE video_id = ?',
+            (video_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            'id': row[0], 'title': row[1], 'webpage_url': row[2],
+            'duration': row[3], 'thumbnail': row[4], 'file_path': row[5],
+        }
+
+    def upsert(self, track: dict, file_path: str):
+        self.conn.execute('''
+            INSERT INTO tracks (video_id, title, webpage_url, duration, thumbnail, file_path)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(video_id) DO UPDATE SET
+                title = excluded.title, webpage_url = excluded.webpage_url,
+                duration = excluded.duration, thumbnail = excluded.thumbnail,
+                file_path = excluded.file_path
+        ''', (
+            track['id'], track['title'], track.get('webpage_url', ''),
+            track.get('duration') or 0, track.get('thumbnail') or '', file_path,
+        ))
+        self.conn.commit()
+
+    def record_play(self, video_id: str):
+        self.conn.execute(
+            "UPDATE tracks SET play_count = play_count + 1, last_played_at = datetime('now') WHERE video_id = ?",
+            (video_id,),
+        )
+        self.conn.commit()
+
+    def delete(self, video_id: str):
+        self.conn.execute('DELETE FROM tracks WHERE video_id = ?', (video_id,))
+        self.conn.commit()
+
+    def evict_lru(self, limit: int) -> list[tuple[str, str]]:
+        """Delete rows past `limit`, oldest-played-first (falls back to download time). Returns (video_id, file_path) evicted."""
+        rows = self.conn.execute(
+            "SELECT video_id, file_path FROM tracks ORDER BY COALESCE(last_played_at, downloaded_at) DESC"
+        ).fetchall()
+        to_evict = rows[limit:]
+        for video_id, _ in to_evict:
+            self.conn.execute('DELETE FROM tracks WHERE video_id = ?', (video_id,))
+        if to_evict:
+            self.conn.commit()
+        return to_evict

--- a/cogs/music_system/youtube.py
+++ b/cogs/music_system/youtube.py
@@ -4,6 +4,7 @@ import base64
 import glob
 import logging
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -12,11 +13,23 @@ from typing import Optional
 
 import yt_dlp
 
+from .db import TrackDB
+
 logger = logging.getLogger('discord.music')
 
 DOWNLOAD_DIR = 'downloads'
 PLAYER_CLIENTS = 'ios,android'
 BOT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_VIDEO_ID_RE = re.compile(
+    r'(?:youtube\.com/(?:watch\?v=|shorts/|embed/)|youtu\.be/)([\w-]{11})'
+)
+
+
+def extract_video_id(url: str) -> Optional[str]:
+    """Pull an 11-char YouTube video id out of a watch/shorts/embed/youtu.be URL, if present."""
+    match = _VIDEO_ID_RE.search(url)
+    return match.group(1) if match else None
 
 
 def find_ytdlp_cmd() -> list[str]:
@@ -119,6 +132,7 @@ class YTDLPClient:
         self.cache_limit = cache_limit
         self._cache: OrderedDict[str, str] = OrderedDict()
         os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+        self.db = TrackDB()
 
     @staticmethod
     def _to_track_dict(entry: dict) -> dict:
@@ -158,6 +172,19 @@ class YTDLPClient:
         except Exception as e:
             logger.error(f"Error extracting '{url}': {e}", exc_info=True)
             return []
+
+    def lookup_cached_url(self, url: str) -> Optional[dict]:
+        """If `url` names a video we already downloaded, return its track dict without hitting the network."""
+        video_id = extract_video_id(url)
+        if not video_id:
+            return None
+        row = self.db.get(video_id)
+        if not row or not os.path.exists(row['file_path']):
+            return None
+        return {
+            'id': row['id'], 'title': row['title'], 'duration': row['duration'],
+            'thumbnail': row['thumbnail'], 'webpage_url': row['webpage_url'],
+        }
 
     async def related(self, video_id: str, exclude_ids: set) -> Optional[dict]:
         """First unseen track from YouTube's auto-generated Mix, for autoplay."""
@@ -214,24 +241,43 @@ class YTDLPClient:
         return matches[0]
 
     async def get_audio_file(self, track: dict) -> Optional[str]:
-        """Cached download: cache hit moves the entry to MRU, miss downloads and evicts LRU past cache_limit."""
+        """Cached download: checks in-memory cache, then the sqlite registry (survives restarts),
+        then downloads. New downloads are recorded in the DB, which drives LRU eviction so the
+        downloads dir stays bounded across the bot's lifetime, not just within one process run.
+        """
         video_id = track['id']
         if video_id in self._cache:
             path = self._cache[video_id]
             if os.path.exists(path):
                 self._cache.move_to_end(video_id)
-                logger.info(f"Cache hit for '{track['title']}' -> {path}")
+                self.db.record_play(video_id)
+                logger.info(f"Cache hit (memory) for '{track['title']}' -> {path}")
                 return path
             del self._cache[video_id]
+
+        row = self.db.get(video_id)
+        if row:
+            if os.path.exists(row['file_path']):
+                self._cache[video_id] = row['file_path']
+                self._cache.move_to_end(video_id)
+                self.db.record_play(video_id)
+                logger.info(f"Cache hit (already downloaded) for '{track['title']}' -> {row['file_path']}")
+                return row['file_path']
+            logger.warning(f"DB row for {video_id} points at missing file, re-downloading")
+            self.db.delete(video_id)
 
         logger.info(f"Cache miss for '{track['title']}' — downloading...")
         path = await self._download(track)
         if not path:
             return None
 
+        self.db.upsert(track, path)
+        self.db.record_play(video_id)
         self._cache[video_id] = path
-        if len(self._cache) > self.cache_limit:
-            _, old_path = self._cache.popitem(last=False)
+        self._cache.move_to_end(video_id)
+
+        for old_id, old_path in self.db.evict_lru(self.cache_limit):
+            self._cache.pop(old_id, None)
             try:
                 if os.path.exists(old_path):
                     os.remove(old_path)

--- a/cogs/music_system/youtube.py
+++ b/cogs/music_system/youtube.py
@@ -107,7 +107,7 @@ class YTDLPClient:
     negotiation more reliably than the Python API on server IPs.
     """
 
-    def __init__(self, cache_limit: int = 100):
+    def __init__(self, cache_limit: int = 1000):
         self.ytdlp_cmd = find_ytdlp_cmd()
         self.cookiefile, self.cookies_from_browser = resolve_cookies()
 


### PR DESCRIPTION
Downloads survive bot restarts now: video_id -> mp3 path is tracked in downloads/tracks.db, so a re-queued song is served from disk instead of hitting yt-dlp again. LRU eviction is driven by the DB (last-played order) rather than the old in-memory-only dict, so the downloads dir stays bounded across restarts too. URL plays for already-downloaded videos skip yt-dlp extraction entirely via a video-id regex lookup.