### PR TITLE
feat - add !mix command for shuffle-loop playback of cached songs

### DIFF
--- a/cogs/music_system/cog.py
+++ b/cogs/music_system/cog.py
@@ -1,6 +1,8 @@
 """Music cog: slash + prefix commands for YouTube playback, queueing, and playback controls."""
 import asyncio
 import logging
+import os
+import random
 
 import discord
 from discord import app_commands
@@ -352,6 +354,39 @@ class Music(commands.Cog):
         removed = player.queue.pop(position - 1)
         logger.info(f"Removed song from position {position}: {removed.title}")
         await ctx.send(f"🗑️ Removed: **{removed.title}**")
+
+    @commands.command(name="mix")
+    async def mix(self, ctx):
+        """Shuffle every cached (already-downloaded) song and loop through them, each once per lap."""
+        if not ctx.author.voice:
+            await ctx.send("❌ You need to be in a voice channel!")
+            return
+
+        rows = self.youtube.db.all_downloaded()
+        tracks = [Track.from_dict(r) for r in rows if os.path.exists(r['file_path'])]
+        if not tracks:
+            await ctx.send("❌ No cached songs yet — play something first!")
+            return
+
+        random.shuffle(tracks)
+
+        try:
+            voice_client = await self._connect(ctx.guild, ctx.author.voice.channel)
+        except Exception as e:
+            logger.error(f"Failed to connect to voice: {e}", exc_info=True)
+            await ctx.send(f"❌ Failed to connect to voice channel: {e}")
+            return
+
+        player = self._get_player(ctx.guild.id, voice_client)
+        player.queue = tracks
+        player.current = None
+        player.loop_mode = LoopMode.QUEUE
+        logger.info(f"Mix started for guild {ctx.guild.id}: {len(tracks)} cached song(s)")
+
+        await ctx.send(f"🔀 Mixing **{len(tracks)}** cached song(s) on shuffle-loop!")
+
+        if not voice_client.is_playing() and not voice_client.is_paused():
+            await self._advance(ctx.guild)
 
     @app_commands.command(name="shuffle", description="Shuffle the queue")
     async def shuffle(self, interaction: discord.Interaction):

--- a/cogs/music_system/db.py
+++ b/cogs/music_system/db.py
@@ -67,6 +67,15 @@ class TrackDB:
         self.conn.execute('DELETE FROM tracks WHERE video_id = ?', (video_id,))
         self.conn.commit()
 
+    def all_downloaded(self) -> list[dict]:
+        rows = self.conn.execute(
+            'SELECT video_id, title, webpage_url, duration, thumbnail, file_path FROM tracks'
+        ).fetchall()
+        return [
+            {'id': r[0], 'title': r[1], 'webpage_url': r[2], 'duration': r[3], 'thumbnail': r[4], 'file_path': r[5]}
+            for r in rows
+        ]
+
     def evict_lru(self, limit: int) -> list[tuple[str, str]]:
         """Delete rows past `limit`, oldest-played-first (falls back to download time). Returns (video_id, file_path) evicted."""
         rows = self.conn.execute(


### PR DESCRIPTION
Pulls every already-downloaded track from tracks.db, shuffles it, and loops the queue so each song plays once per lap. Reuses the existing LoopMode.QUEUE behavior in player.py, no player changes needed.